### PR TITLE
Remove "htaccess" code block language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here's an example:
 
 By default the plugin will build one line per redirect like this:
 
-```htaccess
+```
 RewriteRule ^from-path/?$ /to-path/ [R=301,L]
 ```
 


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `htaccess` is not on the list of [officially supported language tags](https://prismjs.com/#languages-list). Thanks!