### PR TITLE
fs.writeFile flag to append redirects to .htaccess file, should it al…

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -66,7 +66,7 @@ exports.onPostBuild = ({ store }, pluginOptions) => {
       .ensureFile(htaccessPath)
       .then(() => {
         // Write the contents of the file
-        return fs.writeFile(htaccessPath, htaccessContent);
+        return fs.writeFile(htaccessPath, htaccessContent, {'flag':'a'});
       })
       .catch(e => {
         // Log any errors thrown


### PR DESCRIPTION
`fs.writeFile` flag to append redirects to .htaccess file, should it already exist (e.g. if used with [gatsby-plugin-htaccess](https://github.com/AndreasFaust/gatsby-plugin-htaccess))