### PR TITLE
make trailing slash optional

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,12 +13,12 @@ const trimSlashes = fp.trimChars("/");
 // This returns a function with the value of `pattern` bound.
 const redirectToHtaccessStringFactory =
   (pattern) =>
-  ({ fromPath, toPath, isPermanent }) =>
+  ({ fromPath, toPath, isPermanent, withSlash = true }) =>
     pattern
       // Ensure neither leading nor trailing slash
       .replace("%1", trimSlashes(fromPath))
       // Ensure both leading and trailin slashes
-      .replace("%2", `/${trimSlashes(toPath)}/`)
+      .replace("%2", `/${trimSlashes(toPath)}${withSlash ? '/' : ''}`)
       .replace("%3", isPermanent ? "301" : "302");
 // `Redirect ${
 //   isPermanent ? "301" : "302"


### PR DESCRIPTION
I have the use case to create redirects to files, which does not work when the plugin always adds a trailing slash. Since the createRedirect API allows additional parameters, I suggest to add the parameter withSlash which defaults to true.

```javascript
createRedirect({
  fromPath: `/pdf/${node.name}.${node.extension}`,
  toPath: node.publicURL,
  isPermanent: false,
  withSlash: false
});
```